### PR TITLE
Feat/rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Role Variables
 | FORC_TEMPLATE_PATH        | Filesystem path which locates template files for FORC                 | /var/forc/template_path/      | Yes       |
 | FORC_SERVICE_PORT         | The Port on which OpenResty will bind forc to.                        | 5000                          | Yes       |
 | FORC_SERVICE_USE_HTTPS    | If the Forc Backend Service uses HTTPs                                | True                          | Yes       |
+| FORC_LOCAL_IP             | Local IP for Forc Service -- must be set if FORC_SERVICE_USE_HTTPS is false |                        | NO        |
 | FORC_OIDC_DISCOVERY_URL   | OIDC Credentials                                                      | https://login.elixir-czech.org/oidc/.well-known/openid-configuration  | Yes |
 | FORC_OIDC_CLIENT_ID       | OIDC Credentials                                                      |                               | Yes       |
 | FORC_OIDC_CLIENT_SECRET   | OIDC Credentials                                                      |                               | Yes       |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Role Variables
 | FORC_BACKEND_PATH         | Filesystem path in where FORC generates NGINX config snippets to      |    /var/forc/backend_path/    |   Yes     |
 | FORC_TEMPLATE_PATH        | Filesystem path which locates template files for FORC                 | /var/forc/template_path/      | Yes       |
 | FORC_SERVICE_PORT         | The Port on which OpenResty will bind forc to.                        | 5000                          | Yes       |
+| FORC_SERVICE_USE_HTTPS    | If the Forc Backend Service uses HTTPs                                | True                          | Yes       |
 | FORC_OIDC_DISCOVERY_URL   | OIDC Credentials                                                      | https://login.elixir-czech.org/oidc/.well-known/openid-configuration  | Yes |
 | FORC_OIDC_CLIENT_ID       | OIDC Credentials                                                      |                               | Yes       |
 | FORC_OIDC_CLIENT_SECRET   | OIDC Credentials                                                      |                               | Yes       |

--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ To install OpenResty+certbot(+renewal)+FORC:
           FORC_OIDC_CLIENT_SECRET: fmsdgndsogijwsgjtdfogjreowigj
           DOMAIN: "{{ domain }}"
 
+---
+
+### Miscellaneous
+
+Status information like connection details can be accessed from inside the FORC VM using:
+
+```
+curl http://127.0.0.1:8080/nginx_status
+```
+
+
 License
 -------
 

--- a/tasks/025-backup.yml
+++ b/tasks/025-backup.yml
@@ -1,27 +1,95 @@
-- name: "Add Docker GPG apt Key"
-  apt_key:
+---
+- name: Update and upgrade all packages to the latest version
+  ansible.builtin.apt:
+    update_cache: true
+    upgrade: dist
+    cache_valid_time: 3600
+
+- name: Install required packages
+  ansible.builtin.apt:
+    pkg:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+      - software-properties-common
+
+- name: Create directory for Docker's GPG key
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
+- name: Add Docker's official GPG key
+  ansible.builtin.apt_key:
     url: https://download.docker.com/linux/ubuntu/gpg
+    keyring: /etc/apt/keyrings/docker.gpg
     state: present
 
-- name: "Add Docker Repository"
-  apt_repository:
-    repo: "deb https://download.docker.com/linux/ubuntu {{ ansible_lsb.codename|lower }} stable"
+- name: Print architecture variables
+  ansible.builtin.debug:
+    msg: "Architecture: {{ ansible_architecture }}, Codename: {{ ansible_lsb.codename }}"
+
+- name: Add Docker repository
+  ansible.builtin.apt_repository:
+    repo: >-
+      deb [arch={{ arch_mapping[ansible_architecture] | default(ansible_architecture) }}
+      signed-by=/etc/apt/keyrings/docker.gpg]
+      https://download.docker.com/linux/ubuntu {{ ansible_lsb.codename }} stable
+    filename: docker
     state: present
+  vars:
+    arch_mapping:
+      x86_64: amd64
 
-- name: "Update apt and install docker-ce"
-  apt: update_cache=yes name=docker-ce state=latest
+- name: Install Docker and related packages
+  ansible.builtin.apt:
+    name: "{{ item }}"
+    state: present
+    update_cache: true
+  with_items:
+    - docker-buildx-plugin
+    - docker-compose-plugin
 
-- name: "Install Docker Module for Python"
-  pip:
+
+- name: Install Docker
+  apt:
+    name: docker.io
+    state: present
+  tags: install
+
+- name: Configure Docker
+  copy:
+    content: |-
+             {
+                "mtu":{{ ansible_default_ipv4.mtu }}
+             }
+    dest: /etc/docker/daemon.json
+    owner: root
+    group: root
+    mode: "0o644"
+
+- name: Restart Docker Service
+  systemd:
     name: docker
+    state: restarted
 
+- name: Create docker group and change GID
+  group:
+    name: docker
+    gid: 1234
+    state: present
 
-- name: "Ensure the user {{ ansible_user }} is part of the docker group"
+- name: Append ubuntu user to group docker
   user:
-    name: "{{ ansible_user }}"
+    name: ubuntu
+    append: true
     groups: docker
-    append: yes
 
+- name: (Re-)start docker socket
+  systemd:
+    name: docker.socket
+    state: restarted
 
 - name: Create forc backup host folder
   file:

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -89,7 +89,17 @@ server {
         return 301 https://$host$request_uri;
     }
 
-
+    server {
+        listen 127.0.0.1:8080;  # listen only on localhost
+    
+        location /nginx_status {
+            stub_status;
+    
+            # Optional access control
+            allow 127.0.0.1;
+            deny all;
+        }
+    }
     server {
         listen 0.0.0.0:443 ssl http2;
         server_name  {{ DOMAIN }};

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -138,6 +138,7 @@ server {
 
         location / {
                 limit_req zone=perip burst=30 nodelay;
+                limit_req_status 429;
                 access_by_lua_block {
                 -- Start actual openid authentication procedure
                 local res, err = require("resty.openidc").authenticate(opts2)

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -10,6 +10,8 @@ events {
 }
 
 http {
+    limit_req_zone $binary_remote_addr zone=perip:10m rate=10r/s;
+
     include       mime.types;
     lua_package_path "{{ FORC_BACKEND_PATH }}/scripts/?.lua;;";
     default_type  application/octet-stream;
@@ -135,7 +137,7 @@ server {
         set $session_shm_lock_max_step 0.5;
 
         location / {
-
+                limit_req zone=perip burst=30 nodelay;
                 access_by_lua_block {
                 -- Start actual openid authentication procedure
                 local res, err = require("resty.openidc").authenticate(opts2)


### PR DESCRIPTION
Added a base rate limit

How to test: (is already deployed on forc bielefeld staging)

sudo vim /etc/openresty/nginx.conf  (make the same changes like in the pr)
sudo service openresty restart 

--Script to test:

for i in {1..200}; do
  curl -s -o /dev/null -w "%{http_code}\n" https://proxy-dev.bi.denbi.de/ &
done
wait


---

Should print besides 302 some 429 error codes

Also check logs :

ubuntu@gateway-tryout-new:~$ tail -f /usr/local/openresty/nginx/logs/error.log
2025/12/09 09:34:31 [error] 1230975#1230975: *451 limiting requests, excess: 30.230 by zone "perip", client: 129.70.51.75, server: proxy-dev.bi.denbi.de, request: "GET / HTTP/2.0", host: "proxy-dev.bi.denbi.de"
2025/12/09 09:34:31 [error] 1230975#1230975: *451 limiting requests, excess: 30.230 by zone "perip", client: 129.70.51.75, server: proxy-dev.bi.denbi.de, request: "GET / HTTP/2.0", host: "proxy-dev.bi.denbi.de"
2025/12/09 09:34:31 [error] 1230977#1230977: *392 limiting requests, excess: 30.210 by zone "perip", client: 129.70.51.75, server: proxy-dev.bi.denbi.de, request: "GET / HTTP/2.0", host: "proxy-dev.bi.denbi.de"
2025/12/09 09:34:31 [error] 1230977#1230977: *392 limiting requests, excess: 30.210 by zone "perip", client: 129.70.51.75, server: proxy-dev.bi.denbi.de, request: "GET / HTTP/2.0", host: "proxy-dev.bi.denbi.de"
2025/12/09 09:34:31 [error] 1230977#1230977: *392 limiting requests, excess: 30.210 by zone "perip", client: 129.70.51.75, server: proxy-dev.bi.denbi.de, request: "GET / HTTP/2.0", host: "proxy-dev.bi.denbi.de"
2025/12/09 09:34:31 [error] 1230977#1230977: *392 limiting requests, excess: 30.210 by zone "perip", client: 129.70.51.75, server: proxy-dev.bi.denbi.de, request: "GET / HTTP/2.0", host: "proxy-dev.bi.denbi.de"
2025/12/09 09:34:31 [error] 1230977#1230977: *390 limiting requests, excess: 30.200 by zone "perip", client: 129.70.51.75, server: proxy-dev.bi.denbi.de, request: "GET / HTTP/2.0", host: "proxy-dev.bi.denbi.de"
2025/12/09 09:34:31 [error] 1230977#1230977: *390 limiting requests, excess: 30.200 by zone "perip", client: 129.70.51.75, server: proxy-dev.bi.denbi.de, request: "GET / HTTP/2.0", host: "proxy-dev.bi.denbi.de"
2025/12/09 09:34:31 [error] 1230977#1230977: *390 limiting requests, excess: 30.200 by zone "perip", client: 129.70.51.75, server: proxy-dev.bi.denbi.de, request: "GET / HTTP/2.0", host: "proxy-dev.bi.denbi.de"
2025/12/09 09:34:31 [error] 1230977#1230977: *390 limiting requests, excess: 30.200 by zone "perip", client: 129.70.51.75, server: proxy-dev.bi.denbi.de, request: "GET / HTTP/2.0", host: "proxy-dev.bi.denbi.de"

